### PR TITLE
Cycles: fixed crashes when using OSL

### DIFF
--- a/intern/cycles/kernel/osl/osl_shader.cpp
+++ b/intern/cycles/kernel/osl/osl_shader.cpp
@@ -273,7 +273,7 @@ static void flatten_background_closure_tree(ShaderData *sd,
 	}
 }
 
-float3 OSLShader::eval_background(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx)
+void OSLShader::eval_background(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx)
 {
 	/* setup shader globals from shader data */
 	OSLThreadData *tdata = kg->osl_tdata;
@@ -291,8 +291,6 @@ float3 OSLShader::eval_background(KernelGlobals *kg, ShaderData *sd, PathState *
 	/* return background color immediately */
 	if(globals->Ci)
 		flatten_background_closure_tree(sd, globals->Ci);
-
-	return make_float3(0.0f, 0.0f, 0.0f);
 }
 
 float3 OSLShader::eval_ao_env(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx)

--- a/intern/cycles/kernel/osl/osl_shader.h
+++ b/intern/cycles/kernel/osl/osl_shader.h
@@ -54,7 +54,7 @@ public:
 
 	/* eval */
 	static void eval_surface(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx);
-	static float3 eval_background(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx);
+	static void eval_background(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx);
 	static float3 eval_ao_env(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx);
 	static void eval_volume(KernelGlobals *kg, ShaderData *sd, PathState *state, int path_flag, ShaderContext ctx);
 	static void eval_displacement(KernelGlobals *kg, ShaderData *sd, ShaderContext ctx);


### PR DESCRIPTION
As it stands, I can't use OSL in the current master, it always crashes. This patch fixes the crash and brings that section of code to parity with blender.org.