### PR TITLE
Fixed a small inconsistency for BKE_cachefile_copy where in the heade…

### DIFF
--- a/source/blender/blenkernel/intern/cachefile.c
+++ b/source/blender/blenkernel/intern/cachefile.c
@@ -100,7 +100,7 @@ void BKE_cachefile_free(CacheFile *cache_file)
 	BLI_freelistN(&cache_file->object_paths);
 }
 
-CacheFile *BKE_cachefile_copy(Main *bmain, const CacheFile *cache_file)
+CacheFile *BKE_cachefile_copy(Main *bmain, CacheFile *cache_file)
 {
 	CacheFile *new_cache_file = BKE_libblock_copy(bmain, &cache_file->id);
 	new_cache_file->handle = NULL;


### PR DESCRIPTION
…r it is defined without a const but the function definition had a const, removed it. This will hopefully allow it to compile in gcc.