### PR TITLE
Alembic attribute improvements

### DIFF
--- a/release/scripts/startup/bl_ui/properties_data_modifier.py
+++ b/release/scripts/startup/bl_ui/properties_data_modifier.py
@@ -288,6 +288,25 @@ class DATA_PT_modifiers(ModifierButtonsPanel, Panel):
         if ob.type == 'MESH':
             box.row().prop(md, "read_data")
 
+        num_attrs = len(md.attributes)
+
+        if 'ATTR' in md.read_data and num_attrs > 0:
+            layout.separator()
+            layout.label(text="Available attributes:")
+
+            box = layout.box()
+            split = box.split()
+            col = split.column()
+
+            half = num_attrs - (num_attrs // 2)
+
+            for attr in md.attributes:
+                if half == 0:
+                    col = split.column()
+
+                col.label(text=attr.name)
+                half -= 1
+
     def CAST(self, layout, ob, md):
         split = layout.split(percentage=0.25)
 

--- a/source/blender/alembic/intern/abc_util.h
+++ b/source/blender/alembic/intern/abc_util.h
@@ -133,6 +133,14 @@ ABC_INLINE void copy_zup_from_yup(float zup[3], const float yup[3])
 	zup[2] = old_yup1;
 }
 
+ABC_INLINE void copy_zup_from_yup(int zup[3], const int yup[3])
+{
+	const int old_yup1 = yup[1];  /* in case zup == yup */
+	zup[0] = yup[0];
+	zup[1] = -yup[2];
+	zup[2] = old_yup1;
+}
+
 ABC_INLINE void copy_zup_from_yup(short zup[3], const short yup[3])
 {
 	const short old_yup1 = yup[1];  /* in case zup == yup */

--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -1596,7 +1596,10 @@ typedef struct MeshSeqCacheModifierData {
 	char object_path[1024];  /* 1024 = FILE_MAX */
 
 	char read_flag;
-	char pad[7];
+	char pad[3];
+
+	int num_attr;
+	char (*attr_names)[64];
 } MeshSeqCacheModifierData;
 
 /* MeshSeqCacheModifierData.read_flag */
@@ -1608,6 +1611,10 @@ enum {
 	MOD_MESHSEQ_READ_ATTR  = (1 << 4),
 	MOD_MESHSEQ_READ_VELS  = (1 << 5),
 };
+
+typedef struct MeshSeqCacheString {
+	char name[64];
+} MeshSeqCacheString;
 
 typedef struct SDefBind {
 	unsigned int *vert_inds;

--- a/source/blender/makesrna/intern/rna_mesh.c
+++ b/source/blender/makesrna/intern/rna_mesh.c
@@ -1964,6 +1964,10 @@ static void UNUSED_FUNCTION(rna_mesh_unused)(void)
 	(void)rna_Mesh_vertex_color_render_index_get;
 	(void)rna_Mesh_vertex_color_render_index_set;
 	(void)rna_Mesh_vertex_color_render_set;
+	(void)rna_Mesh_alembic_float3_prop_index_range;
+	(void)rna_Mesh_alembic_int3_prop_index_range;
+	(void)rna_Mesh_alembic_float_prop_index_range;
+	(void)rna_Mesh_alembic_int_prop_index_range;
 	/* end unused function block */
 }
 

--- a/source/blender/makesrna/intern/rna_modifier.c
+++ b/source/blender/makesrna/intern/rna_modifier.c
@@ -1499,6 +1499,12 @@ static void rna_OpenVDBModifier_display_thickness_set(PointerRNA *ptr, float val
 	sds->display_thickness = value;
 }
 
+static void rna_MeshSequenceCache_attrs_begin(CollectionPropertyIterator *iter, PointerRNA *ptr)
+{
+	MeshSeqCacheModifierData *mcmd = (MeshSeqCacheModifierData *)ptr->data;
+	rna_iterator_array_begin(iter, (void *)mcmd->attr_names, sizeof(*mcmd->attr_names), mcmd->num_attr, 0, NULL);
+}
+
 #else
 
 static PropertyRNA *rna_def_property_subdivision_common(StructRNA *srna, const char type[])
@@ -4751,6 +4757,19 @@ static void rna_def_modifier_meshseqcache(BlenderRNA *brna)
 	RNA_def_property_enum_sdna(prop, NULL, "read_flag");
 	RNA_def_property_enum_items(prop, read_flag_items);
 	RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+	prop = RNA_def_property(srna, "attributes", PROP_COLLECTION, PROP_NONE);
+	RNA_def_property_struct_type(prop, "MeshSeqCacheString");
+	RNA_def_property_collection_funcs(prop, "rna_MeshSequenceCache_attrs_begin", "rna_iterator_array_next",
+	                                  "rna_iterator_array_end", "rna_iterator_array_get", NULL, NULL, NULL, NULL);
+	RNA_def_property_ui_text(prop, "Attributes", "");
+
+	srna = RNA_def_struct(brna, "MeshSeqCacheString", NULL);
+	RNA_def_struct_sdna(srna, "MeshSeqCacheString");
+	RNA_def_struct_ui_text(srna, "Sequence Cache String", "");
+
+	prop = RNA_def_property(srna, "name", PROP_STRING, PROP_NONE);
+	RNA_def_property_ui_text(prop, "Name", "");
 }
 
 static void rna_def_modifier_laplaciandeform(BlenderRNA *brna)

--- a/source/blender/modifiers/intern/MOD_meshsequencecache.c
+++ b/source/blender/modifiers/intern/MOD_meshsequencecache.c
@@ -30,16 +30,21 @@
 #include "DNA_scene_types.h"
 
 #include "BKE_cachefile.h"
+#include "BKE_customdata.h"
 #include "BKE_DerivedMesh.h"
 #include "BKE_global.h"
 #include "BKE_library.h"
 #include "BKE_library_query.h"
 #include "BKE_scene.h"
 
+#include "BLI_string.h"
+
 #include "depsgraph_private.h"
 #include "DEG_depsgraph_build.h"
 
 #include "MOD_modifiertypes.h"
+
+#include "MEM_guardedalloc.h"
 
 #ifdef WITH_ALEMBIC
 #	include "ABC_alembic.h"
@@ -52,13 +57,13 @@ static void initData(ModifierData *md)
 	mcmd->cache_file = NULL;
 	mcmd->object_path[0] = '\0';
 	mcmd->read_flag = MOD_MESHSEQ_READ_ALL;
+	mcmd->attr_names = NULL;
+	mcmd->num_attr = 0;
 }
 
 static void copyData(ModifierData *md, ModifierData *target)
 {
-#if 0
 	MeshSeqCacheModifierData *mcmd = (MeshSeqCacheModifierData *)md;
-#endif
 	MeshSeqCacheModifierData *tmcmd = (MeshSeqCacheModifierData *)target;
 
 	modifier_copyData_generic(md, target);
@@ -66,6 +71,11 @@ static void copyData(ModifierData *md, ModifierData *target)
 	if (tmcmd->cache_file) {
 		id_us_plus(&tmcmd->cache_file->id);
 		tmcmd->reader = NULL;
+	}
+
+	if (mcmd->attr_names) {
+		tmcmd->attr_names = MEM_dupallocN(mcmd->attr_names);
+		tmcmd->num_attr = mcmd->num_attr;
 	}
 }
 
@@ -82,6 +92,12 @@ static void freeData(ModifierData *md)
 		CacheReader_free(mcmd->reader);
 #endif
 		mcmd->reader = NULL;
+	}
+
+	if (mcmd->attr_names) {
+		MEM_freeN(mcmd->attr_names);
+		mcmd->attr_names = NULL;
+		mcmd->num_attr = 0;
 	}
 }
 
@@ -132,7 +148,53 @@ static DerivedMesh *applyModifier(ModifierData *md, Object *ob,
 		modifier_setError(md, "%s", err_str);
 	}
 
-	return result ? result : dm;
+	if (!result) {
+		result = dm;
+	}
+
+	/* Store a list of all attribute names */
+	{
+		CustomData *cd = result->getVertDataLayout(result);
+		int start_type = CD_ALEMBIC_FLOAT;
+		int end_type = CD_ALEMBIC_I3;
+		int start = -1;
+		int end = -1;
+
+		start = CustomData_get_layer_index(cd, start_type);
+
+		while (start < 0 && start_type <= end_type) {
+			start_type++;
+			start = CustomData_get_layer_index(cd, start_type);
+		}
+
+		if (start != -1) {
+			if (end_type == start_type) {
+				end = start;
+			}
+			else {
+				end = CustomData_get_layer_index(cd, end_type);
+
+				while (end < 0 && end_type >= start_type) {
+					end_type--;
+					end = CustomData_get_layer_index(cd, end_type);
+				}
+			}
+
+			while (end < cd->totlayer && cd->layers[end].type == end_type) {
+				end++;
+			}
+
+			mcmd->num_attr = end - start;
+
+			mcmd->attr_names = MEM_mallocN(sizeof(*mcmd->attr_names) * mcmd->num_attr, "alembic_attribute_names");
+
+			for (int i = 0; i < mcmd->num_attr; i++) {
+				BLI_strncpy(mcmd->attr_names[i], cd->layers[start + i].name, 64);
+			}
+		}
+	}
+
+	return result;
 	UNUSED_VARS(flag);
 #else
 	return dm;


### PR DESCRIPTION
This fixes the axis of the imported custom attributes (Y-up to Z-up), and adds a list of available attributes in the Mesh Sequence Cache modifier UI.

Also silences some warnings that were generated by my previous code.