### PR TITLE
Import OpenVDB velocity grids

### DIFF
--- a/release/scripts/startup/bl_ui/properties_data_modifier.py
+++ b/release/scripts/startup/bl_ui/properties_data_modifier.py
@@ -708,6 +708,8 @@ class DATA_PT_modifiers(ModifierButtonsPanel, Panel):
         layout.prop(md, "density")
         layout.prop(md, "heat")
         layout.prop(md, "flame")
+
+        layout.separator()
         layout.prop(md, "color1")
 
         if (md.use_split_color):
@@ -723,6 +725,23 @@ class DATA_PT_modifiers(ModifierButtonsPanel, Panel):
             col.prop(md, "color3", text="")
         else:
             layout.prop(md, "use_split_color")
+
+        layout.separator()
+        layout.prop(md, "velocity1")
+
+        if (md.use_split_velocity):
+            split = layout.split(percentage=0.333333)
+
+            col = split.column()
+
+            col.prop(md, "use_split_velocity")
+
+            col = split.column()
+
+            col.prop(md, "velocity2", text="")
+            col.prop(md, "velocity3", text="")
+        else:
+            layout.prop(md, "use_split_velocity")
 
         layout.separator()
 
@@ -789,6 +808,9 @@ class DATA_PT_modifiers(ModifierButtonsPanel, Panel):
 
             if (md.color1 != 'NONE'):
                 box.label(text="Max color value: {:.6f}".format(md.max_color))
+
+            if (md.velocity1 != 'NONE'):
+                box.label(text="Max velocity value: {:.6f}".format(md.max_velocity))
 
     def PARTICLE_INSTANCE(self, layout, ob, md):
         layout.prop(md, "object")

--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -1652,6 +1652,10 @@ typedef struct OpenVDBModifierData {
 	float density_max;
 	float flame_min;
 	float flame_max;
+
+	char velocity[3][64];  /* Velocity grid names */
+	float max_velocity;
+	float pad1;
 } OpenVDBModifierData;
 
 /* OpenVDBModifierData flags */
@@ -1662,6 +1666,7 @@ enum {
 	MOD_OPENVDB_SPLIT_COLOR     = (1 << 3),
 	MOD_OPENVDB_IS_RENDER       = (1 << 4),
 	MOD_OPENVDB_HAS_DENSITY     = (1 << 5),
+	MOD_OPENVDB_SPLIT_VELOCITY  = (1 << 6),
 };
 
 enum {

--- a/source/blender/makesrna/intern/rna_modifier.c
+++ b/source/blender/makesrna/intern/rna_modifier.c
@@ -1163,16 +1163,16 @@ static void rna_MeshSequenceCache_object_path_update(Main *bmain, Scene *scene, 
 	rna_Modifier_update(bmain, scene, ptr);
 }
 
-static void rna_OpenVDBModifier_set_color_chanels(OpenVDBModifierData *vdbmd)
+static void rna_OpenVDBModifier_set_grid_chanels(OpenVDBModifierData *vdbmd, char grid[3][64])
 {
 	char name[64];
 	int last;
 
-	if (vdbmd->color[0][0] == 0 || vdbmd->color[1][0] != 0 || vdbmd->color[2][0] != 0) {
+	if (grid[0][0] == 0 || grid[1][0] != 0 || grid[2][0] != 0) {
 		return;
 	}
 
-	BLI_strncpy_utf8(name, vdbmd->color[0], sizeof(name));
+	BLI_strncpy_utf8(name, grid[0], sizeof(name));
 	last = strlen(name) - 1;
 
 	if (!ELEM(name[last], '0', '1', 'X')) {
@@ -1184,7 +1184,7 @@ static void rna_OpenVDBModifier_set_color_chanels(OpenVDBModifierData *vdbmd)
 
 		for (int j = 0; j < vdbmd->numgrids; j++) {
 			if (STREQ(name, vdbmd->grids[j])) {
-				BLI_strncpy_utf8(vdbmd->color[i], name, sizeof(vdbmd->color[i]));
+				BLI_strncpy_utf8(grid[i], name, sizeof(grid[i]));
 				break;
 			}
 		}
@@ -1330,7 +1330,7 @@ static void rna_OpenVDBModifier_color1_grid_set(PointerRNA *ptr, int value)
 		BLI_strncpy_utf8(vdbmd->color[0], vdbmd->grids[value - 1], sizeof(vdbmd->color[0]));
 	}
 
-	rna_OpenVDBModifier_set_color_chanels(vdbmd);
+	rna_OpenVDBModifier_set_grid_chanels(vdbmd, vdbmd->color);
 }
 
 static int rna_OpenVDBModifier_color2_grid_get(PointerRNA *ptr)
@@ -1384,6 +1384,89 @@ static void rna_OpenVDBModifier_color3_grid_set(PointerRNA *ptr, int value)
 
 	if (value <= vdbmd->numgrids) {
 		BLI_strncpy_utf8(vdbmd->color[2], vdbmd->grids[value - 1], sizeof(vdbmd->color[2]));
+	}
+}
+
+static int rna_OpenVDBModifier_velocity1_grid_get(PointerRNA *ptr)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	for (int i = 0; i < vdbmd->numgrids; i++) {
+		if (STREQ(vdbmd->velocity[0], vdbmd->grids[i])) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}
+
+static void rna_OpenVDBModifier_velocity1_grid_set(PointerRNA *ptr, int value)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	if (value == 0) {
+		vdbmd->velocity[0][0] = 0;
+		return;
+	}
+
+	if (value <= vdbmd->numgrids) {
+		BLI_strncpy_utf8(vdbmd->velocity[0], vdbmd->grids[value - 1], sizeof(vdbmd->velocity[0]));
+	}
+
+	rna_OpenVDBModifier_set_grid_chanels(vdbmd, vdbmd->velocity);
+}
+
+static int rna_OpenVDBModifier_velocity2_grid_get(PointerRNA *ptr)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	for (int i = 0; i < vdbmd->numgrids; i++) {
+		if (STREQ(vdbmd->velocity[1], vdbmd->grids[i])) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}
+
+static void rna_OpenVDBModifier_velocity2_grid_set(PointerRNA *ptr, int value)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	if (value == 0) {
+		vdbmd->velocity[1][0] = 0;
+		return;
+	}
+
+	if (value <= vdbmd->numgrids) {
+		BLI_strncpy_utf8(vdbmd->velocity[1], vdbmd->grids[value - 1], sizeof(vdbmd->velocity[1]));
+	}
+}
+
+static int rna_OpenVDBModifier_velocity3_grid_get(PointerRNA *ptr)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	for (int i = 0; i < vdbmd->numgrids; i++) {
+		if (STREQ(vdbmd->velocity[2], vdbmd->grids[i])) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}
+
+static void rna_OpenVDBModifier_velocity3_grid_set(PointerRNA *ptr, int value)
+{
+	OpenVDBModifierData *vdbmd = (OpenVDBModifierData *)ptr->data;
+
+	if (value == 0) {
+		vdbmd->velocity[2][0] = 0;
+		return;
+	}
+
+	if (value <= vdbmd->numgrids) {
+		BLI_strncpy_utf8(vdbmd->velocity[2], vdbmd->grids[value - 1], sizeof(vdbmd->velocity[2]));
 	}
 }
 
@@ -5187,6 +5270,30 @@ static void rna_def_modifier_openvdb(BlenderRNA *brna)
 	RNA_def_property_ui_text(prop, "Color Grid", "Name of the grid to be used for the third color component");
 	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
 
+	prop = RNA_def_property(srna, "velocity1", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_items(prop, grid_items);
+	RNA_def_property_enum_funcs(prop, "rna_OpenVDBModifier_velocity1_grid_get", "rna_OpenVDBModifier_velocity1_grid_set",
+	                            "rna_OpenVDBModifier_grid_itemf");
+	RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
+	RNA_def_property_ui_text(prop, "Velocity Grid", "Name of the grid to be used for velocity");
+	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
+
+	prop = RNA_def_property(srna, "velocity2", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_items(prop, grid_items);
+	RNA_def_property_enum_funcs(prop, "rna_OpenVDBModifier_velocity2_grid_get", "rna_OpenVDBModifier_velocity2_grid_set",
+	                            "rna_OpenVDBModifier_grid_itemf");
+	RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
+	RNA_def_property_ui_text(prop, "Velocity Grid", "Name of the grid to be used for the second velocity component");
+	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
+
+	prop = RNA_def_property(srna, "velocity3", PROP_ENUM, PROP_NONE);
+	RNA_def_property_enum_items(prop, grid_items);
+	RNA_def_property_enum_funcs(prop, "rna_OpenVDBModifier_velocity3_grid_get", "rna_OpenVDBModifier_velocity3_grid_set",
+	                            "rna_OpenVDBModifier_grid_itemf");
+	RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
+	RNA_def_property_ui_text(prop, "Velocity Grid", "Name of the grid to be used for the third velocity component");
+	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
+
 	prop = RNA_def_property(srna, "up_axis", PROP_ENUM, PROP_NONE);
 	RNA_def_property_enum_items(prop, axis_items);
 	RNA_def_property_ui_text(prop, "Up Axis", "Axis to point upwards");
@@ -5254,6 +5361,12 @@ static void rna_def_modifier_openvdb(BlenderRNA *brna)
 	RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
 	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
 
+	prop = RNA_def_property(srna, "use_split_velocity", PROP_BOOLEAN, PROP_NONE);
+	RNA_def_property_boolean_sdna(prop, NULL, "flags", MOD_OPENVDB_SPLIT_VELOCITY);
+	RNA_def_property_ui_text(prop, "Split Velocity", "Input velocity grids by individual channel");
+	RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
+	RNA_def_property_update(prop, 0, "rna_OpenVDBModifier_update");
+
 	prop = RNA_def_property(srna, "show_axis_convert", PROP_BOOLEAN, PROP_NONE);
 	RNA_def_property_boolean_funcs(prop, "rna_OpenVDBModifier_show_axis_convert_get", NULL);
 	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
@@ -5268,6 +5381,9 @@ static void rna_def_modifier_openvdb(BlenderRNA *brna)
 	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
 
 	prop = RNA_def_property(srna, "max_color", PROP_FLOAT, PROP_NONE);
+	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
+
+	prop = RNA_def_property(srna, "max_velocity", PROP_FLOAT, PROP_NONE);
 	RNA_def_property_clear_flag(prop, PROP_EDITABLE);
 
 	prop = RNA_def_property(srna, "numeric_display", PROP_ENUM, PROP_NONE);


### PR DESCRIPTION
This imports the OpenVDB velocity grid into Blender's own data
structure, making it available for rendering.