### PR TITLE
Deferred ray march

### DIFF
--- a/intern/cycles/kernel/kernel_path.h
+++ b/intern/cycles/kernel/kernel_path.h
@@ -98,7 +98,7 @@ ccl_device_noinline void kernel_path_ao(KernelGlobals *kg,
         state->flag |= PATH_RAY_AO;
 
         uint shadow_linking = object_shadow_linking(kg, sd->object);
-		if(!shadow_blocked(kg, emission_sd, state, &light_ray, &ao_shadow, shadow_linking))
+		if(!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &ao_shadow, shadow_linking))
 			path_radiance_accum_ao(L, throughput, ao_alpha, ao_bsdf, ao_shadow, state->bounce);
 
         state->flag &= ~PATH_RAY_AO;

--- a/intern/cycles/kernel/kernel_path_branched.h
+++ b/intern/cycles/kernel/kernel_path_branched.h
@@ -434,7 +434,7 @@ ccl_device float4 kernel_branched_path_integrate(KernelGlobals *kg, RNG *rng, in
 					RNG tmp_rng = cmj_hash(*rng, state.rng_offset);
 
 					PathState ps = state;
-					Ray pray = ray;
+					Ray pray = volume_ray;
 					float3 tp = throughput;
 
 					/* branch RNG state */

--- a/intern/cycles/kernel/kernel_path_branched.h
+++ b/intern/cycles/kernel/kernel_path_branched.h
@@ -449,6 +449,8 @@ ccl_device float4 kernel_branched_path_integrate(KernelGlobals *kg, RNG *rng, in
 					VolumeIntegrateResult result = kernel_volume_decoupled_scatter(kg,
 						&ps, &pray, &sd, &tp, rphase, rscatter, &volume_segment, NULL, false);
 
+					kernel_volume_branch_stack(sd.ray_length, ps.volume_stack);
+
 					(void)result;
 					kernel_assert(result == VOLUME_PATH_SCATTERED);
 
@@ -508,6 +510,8 @@ ccl_device float4 kernel_branched_path_integrate(KernelGlobals *kg, RNG *rng, in
 
 				VolumeIntegrateResult result = kernel_volume_integrate(
 					kg, &ps, &sd, &volume_ray, &L, &tp, rng, heterogeneous);
+
+				kernel_volume_branch_stack(sd.ray_length, ps.volume_stack);
 
 #ifdef __VOLUME_SCATTER__
 				if(result == VOLUME_PATH_SCATTERED) {

--- a/intern/cycles/kernel/kernel_path_surface.h
+++ b/intern/cycles/kernel/kernel_path_surface.h
@@ -64,7 +64,7 @@ ccl_device_noinline void kernel_branched_path_surface_connect_light(KernelGlobal
 						/* trace shadow ray */
 						float3 shadow;
 
-						if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+						if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 							/* accumulate */
 							path_radiance_accum_light(L, throughput*num_samples_inv, &L_light, shadow, num_samples_inv, state->bounce, is_lamp);
 						}
@@ -101,7 +101,7 @@ ccl_device_noinline void kernel_branched_path_surface_connect_light(KernelGlobal
 						/* trace shadow ray */
 						float3 shadow;
 
-						if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+						if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 							/* accumulate */
 							path_radiance_accum_light(L, throughput*num_samples_inv, &L_light, shadow, num_samples_inv, state->bounce, is_lamp);
 						}
@@ -127,7 +127,7 @@ ccl_device_noinline void kernel_branched_path_surface_connect_light(KernelGlobal
 				/* trace shadow ray */
 				float3 shadow;
 
-				if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+				if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 					/* accumulate */
 					path_radiance_accum_light(L, throughput*num_samples_adjust, &L_light, shadow, num_samples_adjust, state->bounce, is_lamp);
 				}
@@ -259,7 +259,7 @@ ccl_device_inline void kernel_path_surface_connect_light(KernelGlobals *kg,
 			/* trace shadow ray */
 			float3 shadow;
 
-			if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+			if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 				/* accumulate */
 				path_radiance_accum_light(L, throughput, &L_light, shadow, 1.0f, state->bounce, is_lamp);
 			}

--- a/intern/cycles/kernel/kernel_path_volume.h
+++ b/intern/cycles/kernel/kernel_path_volume.h
@@ -54,7 +54,7 @@ ccl_device_inline void kernel_path_volume_connect_light(
 			/* trace shadow ray */
 			float3 shadow;
 
-			if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+			if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 				/* accumulate */
 				path_radiance_accum_light(L, throughput, &L_light, shadow, 1.0f, state->bounce, is_lamp);
 			}
@@ -179,7 +179,7 @@ ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg, RNG
 						/* trace shadow ray */
 						float3 shadow;
 
-						if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+						if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 							/* accumulate */
 							path_radiance_accum_light(L, tp*num_samples_inv, &L_light, shadow, num_samples_inv, state->bounce, is_lamp);
 						}
@@ -228,7 +228,7 @@ ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg, RNG
 						/* trace shadow ray */
 						float3 shadow;
 
-						if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+						if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 							/* accumulate */
 							path_radiance_accum_light(L, tp*num_samples_inv, &L_light, shadow, num_samples_inv, state->bounce, is_lamp);
 						}
@@ -266,7 +266,7 @@ ccl_device void kernel_branched_path_volume_connect_light(KernelGlobals *kg, RNG
 				/* trace shadow ray */
 				float3 shadow;
 
-				if (!shadow_blocked(kg, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
+				if (!shadow_blocked(kg, sd, emission_sd, state, &light_ray, &shadow, shadow_linking)) {
 					/* accumulate */
 					path_radiance_accum_light(L, tp, &L_light, shadow, 1.0f, state->bounce, is_lamp);
 				}

--- a/intern/cycles/kernel/kernel_shader.h
+++ b/intern/cycles/kernel/kernel_shader.h
@@ -1236,6 +1236,10 @@ ccl_device_inline void shader_eval_volume(KernelGlobals *kg,
 	sd->object_flag = 0;
 
 	for(int i = 0; stack[i].shader != SHADER_NONE; i++) {
+		/* Skip volumes that don't overlap the current point. */
+		if(stack[i].t_enter > sd->ray_length || stack[i].t_exit < sd->ray_length) {
+			continue;
+		}
 		/* setup shaderdata from stack. it's mostly setup already in
 		 * shader_setup_from_volume, this switching should be quick */
 		sd->object = stack[i].object;

--- a/intern/cycles/kernel/kernel_shadow.h
+++ b/intern/cycles/kernel/kernel_shadow.h
@@ -88,21 +88,7 @@ ccl_device_inline bool shadow_blocked(KernelGlobals *kg, ShaderData *sd, ShaderD
 			Intersection *isect = hits;
 #ifdef __VOLUME__
 			PathState ps = *state;
-			/* Remove all non-overlapping volumes from the stack. */
-			for(int i = 0; ps.volume_stack[i].shader != SHADER_NONE; ++i) {
-				if(ps.volume_stack[i].t_exit < sd->ray_length || ps.volume_stack[i].t_enter > sd->ray_length) {
-					int j = i;
-					/* shift back next stack entries */
-					do {
-						ps.volume_stack[j] = ps.volume_stack[j+1];
-						++j;
-					}
-					while(ps.volume_stack[j].shader != SHADER_NONE);
-					--i;
-				}
-				ps.volume_stack[i].t_enter = 0.0f;
-				ps.volume_stack[i].t_exit = FLT_MAX;
-			}
+			kernel_volume_branch_stack(sd->ray_length, ps.volume_stack);
 #endif
 #	ifndef __KERNEL_GPU__
 			qsort(hits, num_hits, sizeof(Intersection), intersections_compare);
@@ -242,21 +228,7 @@ ccl_device_noinline bool shadow_blocked(KernelGlobals *kg,
 			int bounce = state->transparent_bounce;
 #ifdef __VOLUME__
 			PathState ps = *state;
-			/* Remove all non-overlapping volumes from the stack. */
-			for(int i = 0; ps.volume_stack[i].shader != SHADER_NONE; ++i) {
-				if(ps.volume_stack[i].t_exit < sd->ray_length || ps.volume_stack[i].t_enter > sd->ray_length) {
-					int j = i;
-					/* shift back next stack entries */
-					do {
-						ps.volume_stack[j] = ps.volume_stack[j+1];
-						++j;
-					}
-					while(ps.volume_stack[j].shader != SHADER_NONE);
-					--i;
-				}
-				ps.volume_stack[i].t_enter = 0.0f;
-				ps.volume_stack[i].t_exit = FLT_MAX;
-			}
+			kernel_volume_branch_stack(sd->ray_length, ps.volume_stack);
 #endif
 
 			for (;;) {

--- a/intern/cycles/kernel/kernel_shadow.h
+++ b/intern/cycles/kernel/kernel_shadow.h
@@ -41,7 +41,7 @@ CCL_NAMESPACE_BEGIN
 
 #define STACK_MAX_HITS 64
 
-ccl_device_inline bool shadow_blocked(KernelGlobals *kg, ShaderData *shadow_sd, PathState *state, Ray *ray, float3 *shadow, uint shadow_linking)
+ccl_device_inline bool shadow_blocked(KernelGlobals *kg, ShaderData *sd, ShaderData *shadow_sd, PathState *state, Ray *ray, float3 *shadow, uint shadow_linking)
 {
 	*shadow = make_float3(1.0f, 1.0f, 1.0f);
 
@@ -88,6 +88,21 @@ ccl_device_inline bool shadow_blocked(KernelGlobals *kg, ShaderData *shadow_sd, 
 			Intersection *isect = hits;
 #ifdef __VOLUME__
 			PathState ps = *state;
+			/* Remove all non-overlapping volumes from the stack. */
+			for(int i = 0; ps.volume_stack[i].shader != SHADER_NONE; ++i) {
+				if(ps.volume_stack[i].t_exit < sd->ray_length || ps.volume_stack[i].t_enter > sd->ray_length) {
+					int j = i;
+					/* shift back next stack entries */
+					do {
+						ps.volume_stack[j] = ps.volume_stack[j+1];
+						++j;
+					}
+					while(ps.volume_stack[j].shader != SHADER_NONE);
+					--i;
+				}
+				ps.volume_stack[i].t_enter = 0.0f;
+				ps.volume_stack[i].t_exit = FLT_MAX;
+			}
 #endif
 #	ifndef __KERNEL_GPU__
 			qsort(hits, num_hits, sizeof(Intersection), intersections_compare);
@@ -195,6 +210,7 @@ ccl_device_inline bool shadow_blocked(KernelGlobals *kg, ShaderData *shadow_sd, 
 * one extra ray cast for the cases were we do want transparency. */
 
 ccl_device_noinline bool shadow_blocked(KernelGlobals *kg,
+										ShaderData *sd,
 										ShaderData *shadow_sd,
 										ccl_addr_space PathState *state,
 										ccl_addr_space Ray *ray_input,
@@ -226,6 +242,21 @@ ccl_device_noinline bool shadow_blocked(KernelGlobals *kg,
 			int bounce = state->transparent_bounce;
 #ifdef __VOLUME__
 			PathState ps = *state;
+			/* Remove all non-overlapping volumes from the stack. */
+			for(int i = 0; ps.volume_stack[i].shader != SHADER_NONE; ++i) {
+				if(ps.volume_stack[i].t_exit < sd->ray_length || ps.volume_stack[i].t_enter > sd->ray_length) {
+					int j = i;
+					/* shift back next stack entries */
+					do {
+						ps.volume_stack[j] = ps.volume_stack[j+1];
+						++j;
+					}
+					while(ps.volume_stack[j].shader != SHADER_NONE);
+					--i;
+				}
+				ps.volume_stack[i].t_enter = 0.0f;
+				ps.volume_stack[i].t_exit = FLT_MAX;
+			}
 #endif
 
 			for (;;) {

--- a/intern/cycles/kernel/kernel_types.h
+++ b/intern/cycles/kernel/kernel_types.h
@@ -962,6 +962,11 @@ typedef ccl_addr_space struct ShaderData {
 typedef struct VolumeStack {
 	int object;
 	int shader;
+	/* These indicate the entry and exit points of the current ray.
+	   Volume shaders are only to be evaluated when the ray's t
+	   overlaps the volume bounds. */
+	float t_enter;
+	float t_exit;
 } VolumeStack;
 #endif
 

--- a/intern/cycles/kernel/kernel_volume.h
+++ b/intern/cycles/kernel/kernel_volume.h
@@ -61,6 +61,26 @@ ccl_device_inline bool volume_shader_extinction_sample(KernelGlobals *kg,
 	return true;
 }
 
+ccl_device_inline void kernel_volume_branch_stack(float distance, VolumeStack *stack)
+{
+	/* Remove all non-overlapping volumes from the stack.
+	   Set all other volumes to go from zero to infinity.
+	 */
+	for (int i = 0; stack[i].shader != SHADER_NONE; ++i) {
+		if (stack[i].t_exit <distance ||stack[i].t_enter > distance) {
+			int j = i;
+			/* shift back next stack entries */
+			do {
+				stack[j] = stack[j + 1];
+				++j;
+			} while(stack[j].shader != SHADER_NONE);
+			--i;
+		}
+		stack[i].t_enter = 0.0f;
+		stack[i].t_exit = FLT_MAX;
+	}
+}
+
 /* evaluate shader to get absorption, scattering and emission at P */
 ccl_device_inline bool volume_shader_sample(KernelGlobals *kg,
                                             ShaderData *sd,

--- a/intern/cycles/kernel/split/kernel_shadow_blocked_ao.h
+++ b/intern/cycles/kernel/split/kernel_shadow_blocked_ao.h
@@ -42,6 +42,7 @@ ccl_device void kernel_shadow_blocked_ao(KernelGlobals *kg)
 		float3 shadow;
 		Ray ray = *light_ray_global;
 		update_path_radiance = !(shadow_blocked(kg,
+												&kernel_split_state.sd[ray_index],
 		                                        &kernel_split_state.sd_DL_shadow[ray_index],
 		                                        state,
 		                                        &ray,

--- a/intern/cycles/kernel/split/kernel_shadow_blocked_dl.h
+++ b/intern/cycles/kernel/split/kernel_shadow_blocked_dl.h
@@ -42,6 +42,7 @@ ccl_device void kernel_shadow_blocked_dl(KernelGlobals *kg)
 		float3 shadow;
 		Ray ray = *light_ray_global;
 		update_path_radiance = !(shadow_blocked(kg,
+												&kernel_split_state.sd[ray_index],
 		                                        &kernel_split_state.sd_DL_shadow[ray_index],
 		                                        state,
 		                                        &ray,


### PR DESCRIPTION
This fixes the overlapping volume problem:

When rendering overlapping volumes with branched path tracing, Cycles would do a separate ray march pass at each surface intersection, so whenever there was overlap, there would be more samples drawn than when there was none. Combined with bright emission and sample clamping, this could cause visible lines at the volume intersections. This patch changes it so that overlapping volumes are handled in a single ray march pass.