### PR TITLE
Misc fixes

### DIFF
--- a/intern/cycles/blender/blender_mesh.cpp
+++ b/intern/cycles/blender/blender_mesh.cpp
@@ -1071,6 +1071,9 @@ static void sync_mesh_alembic_motion(BL::Mesh& b_mesh, Scene *scene, Mesh *mesh)
 	if(b_mesh.velocities.length() != mesh->verts.size())
 		return;
 
+	if (mesh->verts.size() == 0)
+		return;
+
 	/* Find or add attribute */
 	float3 *P = &mesh->verts[0];
 	Attribute *attr_mP = mesh->attributes.find(ATTR_STD_MOTION_VERTEX_POSITION);

--- a/intern/cycles/blender/blender_mesh.cpp
+++ b/intern/cycles/blender/blender_mesh.cpp
@@ -1037,8 +1037,11 @@ static void sync_mesh_fluid_motion(BL::Object& b_ob, Scene *scene, Mesh *mesh)
 		return;
 
 	/* If the mesh has modifiers following the fluid domain we can't export motion. */
-	if(b_fluid_domain.fluid_mesh_vertices.length() != mesh->verts.size())
+	if (b_fluid_domain.fluid_mesh_vertices.length() != mesh->verts.size()) {
+		VLOG(1) << "Topology differs, disabling motion blur for object "
+			<< b_ob.name();
 		return;
+	}
 
 	/* Find or add attribute */
 	float3 *P = &mesh->verts[0];

--- a/intern/cycles/kernel/kernel_path_branched.h
+++ b/intern/cycles/kernel/kernel_path_branched.h
@@ -391,11 +391,11 @@ ccl_device void kernel_branched_path_integrate(KernelGlobals *kg, RNG *rng, int 
 		else {
 			int i = (kernel_data.background.volume_shader != SHADER_NONE) ? 1 : 0;
 			do {
-				if(state.volume_stack[i].t_exit == FLT_MAX) {
-					kernel_volume_stack_remove(kg, state.volume_stack[i].object, state.volume_stack);
+				if(state.volume_stack[i].t_exit != FLT_MAX) {
+					++i;
 				}
 				else {
-					++i;
+					kernel_volume_stack_remove(kg, state.volume_stack[i].object, state.volume_stack);
 				}
 			} while(i < VOLUME_STACK_SIZE && state.volume_stack[i].shader != SHADER_NONE);
 		}


### PR DESCRIPTION
These are a few small fixes:

* Added a Log message when Cycles can't apply motion blur to fluids due to changing vertex count.
* Preventing an infinite loop in volume tracking when rays with NaN distance show up.
* Fixed a potentially illegal dereference with empty alembic meshes (Visual Studio Debugger complained about it).