### PR TITLE
Cycles: don't count volume boundaries as transparent bounces.

### DIFF
--- a/intern/cycles/kernel/kernel_path.h
+++ b/intern/cycles/kernel/kernel_path.h
@@ -331,6 +331,11 @@ ccl_device void kernel_path_indirect(KernelGlobals *kg,
 		                      sd,
 		                      &isect,
 		                      ray);
+
+/* Skip most work for volume bounding surface. */
+#ifdef __VOLUME__
+		if (!(sd->shader_flag & SD_SHADER_HAS_ONLY_VOLUME)) {
+#endif
 		float rbsdf = path_state_rng_1D_for_decision(kg, rng, state, PRNG_BSDF);
 		shader_eval_surface(kg, sd, rng, state, rbsdf, state->flag, SHADER_CONTEXT_INDIRECT, NULL, 0);
 #ifdef __BRANCHED_PATH__
@@ -449,6 +454,9 @@ ccl_device void kernel_path_indirect(KernelGlobals *kg,
 		}
 #endif  /* defined(__EMISSION__) && defined(__BRANCHED_PATH__) */
 
+#ifdef __VOLUME__
+		}
+#endif
 		if(!kernel_path_surface_bounce(kg, rng, sd, &throughput, state, L, ray))
 			break;
 	}
@@ -831,6 +839,11 @@ ccl_device_inline void kernel_path_integrate(KernelGlobals *kg,
 
 		/* setup shading */
 		shader_setup_from_ray(kg, &sd, &isect, &ray);
+
+		/* Skip most work for volume bounding surface. */
+#ifdef __VOLUME__
+		if (!(sd.shader_flag & SD_SHADER_HAS_ONLY_VOLUME)) {
+#endif
 		float rbsdf = path_state_rng_1D_for_decision(kg, rng, &state, PRNG_BSDF);
 		shader_eval_surface(kg, &sd, rng, &state, rbsdf, state.flag, SHADER_CONTEXT_MAIN, buffer, sample);
 
@@ -943,6 +956,10 @@ ccl_device_inline void kernel_path_integrate(KernelGlobals *kg,
         uint shadow_linking = object_shadow_linking(kg, sd.object);
 
 		kernel_path_surface_connect_light(kg, rng, &sd, &emission_sd, throughput, &state, &L, light_linking, shadow_linking);
+
+#ifdef __VOLUME__
+		}
+#endif
 
 		/* compute direct lighting and next bounce */
 		if(!kernel_path_surface_bounce(kg, rng, &sd, &throughput, &state, &L, &ray))

--- a/intern/cycles/kernel/kernel_path_state.h
+++ b/intern/cycles/kernel/kernel_path_state.h
@@ -53,6 +53,7 @@ ccl_device_inline void path_state_init(KernelGlobals *kg,
 
 #ifdef __VOLUME__
 	state->volume_bounce = 0;
+	state->volume_bounds_bounce = 0;
 
 	if(kernel_data.integrator.use_volumes) {
 		/* Initialize volume stack with volume we are inside of. */

--- a/intern/cycles/kernel/kernel_path_surface.h
+++ b/intern/cycles/kernel/kernel_path_surface.h
@@ -342,10 +342,12 @@ ccl_device bool kernel_path_surface_bounce(KernelGlobals *kg,
 	}
 #ifdef __VOLUME__
 	else if(ccl_fetch(sd, shader_flag) & SD_SHADER_HAS_ONLY_VOLUME) {
-		/* no surface shader but have a volume shader? act transparent */
-
-		/* update path state, count as transparent */
-		path_state_next(kg, state, LABEL_TRANSPARENT);
+		/* For volume bounding meshes we pass through without counting transparent
+		 * bounces, only sanity check in case self intersection gets us stuck. */
+		state->volume_bounds_bounce++;
+		if (state->volume_bounds_bounce > VOLUME_BOUNDS_MAX) {
+			return false;
+		}
 
 		if(state->bounce == 0)
 			ray->t -= sd->ray_length; /* clipping works through transparent */

--- a/intern/cycles/kernel/kernel_types.h
+++ b/intern/cycles/kernel/kernel_types.h
@@ -53,6 +53,8 @@ CCL_NAMESPACE_BEGIN
 #define BSSRDF_MIN_RADIUS			1e-8f
 #define BSSRDF_MAX_HITS				4
 
+#define VOLUME_BOUNDS_MAX       1024
+
 #define BECKMANN_TABLE_SIZE		256
 
 #define SHADER_NONE				(~0)
@@ -1009,6 +1011,7 @@ typedef struct PathState {
 #ifdef __VOLUME__
 	int volume_bounce;
 	RNG rng_congruential;
+	int volume_bounds_bounce;
 	VolumeStack volume_stack[VOLUME_STACK_SIZE];
 #endif
 
@@ -1396,8 +1399,10 @@ enum RayState {
 	RAY_ACTIVE,
 	/* Denotes ray has completed processing all samples and is inactive. */
 	RAY_INACTIVE,
-	/* Denoted ray has exited path-iteration and needs to update output buffer. */
+	/* Denotes ray has exited path-iteration and needs to update output buffer. */
 	RAY_UPDATE_BUFFER,
+	/* Denotes ray needs to skip most surface shader work. */
+	RAY_HAS_ONLY_VOLUME,
 	/* Donotes ray has hit background */
 	RAY_HIT_BACKGROUND,
 	/* Denotes ray has to be regenerated */

--- a/intern/cycles/kernel/split/kernel_queue_enqueue.h
+++ b/intern/cycles/kernel/split/kernel_queue_enqueue.h
@@ -55,6 +55,7 @@ ccl_device void kernel_queue_enqueue(KernelGlobals *kg,
 		queue_number = QUEUE_HITBG_BUFF_UPDATE_TOREGEN_RAYS;
 	}
 	else if(IS_STATE(kernel_split_state.ray_state, ray_index, RAY_ACTIVE) ||
+	        IS_STATE(kernel_split_state.ray_state, ray_index, RAY_HAS_ONLY_VOLUME) ||
 	        IS_STATE(kernel_split_state.ray_state, ray_index, RAY_REGENERATED)) {
 		queue_number = QUEUE_ACTIVE_AND_REGENERATED_RAYS;
 	}

--- a/intern/cycles/kernel/split/kernel_shader_setup.h
+++ b/intern/cycles/kernel/split/kernel_shader_setup.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2011-2017 Blender Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CCL_NAMESPACE_BEGIN
+
+/* This kernel sets up the ShaderData structure from the values computed
+ * by the previous kernels.
+ *
+ * It also identifies the rays of state RAY_TO_REGENERATE and enqueues them
+ * in QUEUE_HITBG_BUFF_UPDATE_TOREGEN_RAYS queue.
+ */
+ccl_device void kernel_shader_setup(KernelGlobals *kg,
+                                    ccl_local_param unsigned int *local_queue_atomics)
+{
+	/* Enqeueue RAY_TO_REGENERATE rays into QUEUE_HITBG_BUFF_UPDATE_TOREGEN_RAYS queue. */
+	if(ccl_local_id(0) == 0 && ccl_local_id(1) == 0) {
+		*local_queue_atomics = 0;
+	}
+	ccl_barrier(CCL_LOCAL_MEM_FENCE);
+
+	int ray_index = ccl_global_id(1) * ccl_global_size(0) + ccl_global_id(0);
+	int queue_index = kernel_split_params.queue_index[QUEUE_ACTIVE_AND_REGENERATED_RAYS];
+	if(ray_index >= queue_index) {
+		return;
+	}
+	ray_index = get_ray_index(kg, ray_index,
+	                          QUEUE_ACTIVE_AND_REGENERATED_RAYS,
+	                          kernel_split_state.queue_data,
+	                          kernel_split_params.queue_size,
+	                          0);
+
+	if(ray_index == QUEUE_EMPTY_SLOT) {
+		return;
+	}
+
+	char enqueue_flag = (IS_STATE(kernel_split_state.ray_state, ray_index, RAY_TO_REGENERATE)) ? 1 : 0;
+	enqueue_ray_index_local(ray_index,
+	                        QUEUE_HITBG_BUFF_UPDATE_TOREGEN_RAYS,
+	                        enqueue_flag,
+	                        kernel_split_params.queue_size,
+	                        local_queue_atomics,
+	                        kernel_split_state.queue_data,
+	                        kernel_split_params.queue_index);
+
+	/* Continue on with shader evaluation. */
+	if(IS_STATE(kernel_split_state.ray_state, ray_index, RAY_ACTIVE)) {
+		Intersection isect = kernel_split_state.isect[ray_index];
+		Ray ray = kernel_split_state.ray[ray_index];
+		ShaderData *sd = kernel_split_sd(sd, ray_index);
+
+		shader_setup_from_ray(kg,
+		                      sd,
+		                      &isect,
+		                      &ray);
+
+#ifdef __VOLUME__
+		if(sd->flag & SD_HAS_ONLY_VOLUME) {
+			ASSIGN_RAY_STATE(kernel_split_state.ray_state, ray_index, RAY_HAS_ONLY_VOLUME);
+		}
+#endif
+	}
+
+}
+
+CCL_NAMESPACE_END


### PR DESCRIPTION
This is more important now that we will have tigther volume bounds that
we hit multiple times. It also avoids some noise due to RR previously
affecting these surfaces, which shouldn't have been the case and should
eventually be fixed for transparent BSDFs as well.

For non-volume scenes I found no performance impact on NVIDIA or AMD.
For volume scenes the noise decrease and fixed artifacts are worth the
little extra render time, when there is any.