### PR TITLE
This fixes compiler errors that prevent Blender from building in Xcod…

### DIFF
--- a/intern/cycles/blender/blender_object.cpp
+++ b/intern/cycles/blender/blender_object.cpp
@@ -414,7 +414,7 @@ Object *BlenderSync::sync_object(BL::Object& b_parent,
 			);
 		}
 
-		printf( "CYCLES: Generated object \"%s\", Dupli ID %u\n", object->name, object->random_id );
+		printf( "CYCLES: Generated object \"%s\", Dupli ID %u\n", object->name.c_str(), object->random_id );
 		if (b_dupli_ob) {
 			printf( "\t dupli object\n" );
 		}

--- a/intern/openvdb/intern/openvdb_dense_convert.cc
+++ b/intern/openvdb/intern/openvdb_dense_convert.cc
@@ -272,7 +272,7 @@ openvdb::math::Transform::Ptr OpenVDB_get_grid_transform(
 	using namespace openvdb;
 
 	if (!reader->hasGrid(name)) {
-		return NULL;
+		return openvdb::math::Transform::Ptr();
 	}
 
 	GridBase::Ptr grid = reader->getGrid(name);


### PR DESCRIPTION
…e on a Mac. May also have affected Clang builds on other platforms.

It also fixes the printing of garbage characters before rendering in the "generated object ..." message.