### PR TITLE
Fix alembic updating with multiple caches

### DIFF
--- a/source/blender/blenkernel/intern/cachefile.c
+++ b/source/blender/blenkernel/intern/cachefile.c
@@ -171,7 +171,6 @@ void BKE_cachefile_update_frame(Main *bmain, Scene *scene, const float ctime, co
 			ABC_free_handle(cache_file->handle);
 			cache_file->handle = ABC_create_handle(filename, NULL);
 #endif
-			break;
 		}
 	}
 }


### PR DESCRIPTION
This fixes cache updating when loading multiple Alembic files into the same scene.