### PR TITLE
OpenVDB: Fix hidden volume displaying in viewport after render

### DIFF
--- a/source/blender/editors/space_view3d/drawobject.c
+++ b/source/blender/editors/space_view3d/drawobject.c
@@ -7929,7 +7929,8 @@ void draw_object(Scene *scene, ARegion *ar, View3D *v3d, Base *base, const short
 			p1[1] = (sds->p0[1] + sds->cell_size[1] * sds->res_max[1] + sds->obj_shift_f[1]) * fabsf(ob->size[1]);
 			p1[2] = (sds->p0[2] + sds->cell_size[2] * sds->res_max[2] + sds->obj_shift_f[2]) * fabsf(ob->size[2]);
 
-			if (!sds->vdb || !((sds->vdb->flags & MOD_OPENVDB_HIDE_UNSELECTED) && !(ob->flag & SELECT)))
+			if (!sds->vdb || (!((sds->vdb->flags & MOD_OPENVDB_HIDE_UNSELECTED) && !(ob->flag & SELECT)) &&
+			                  !(sds->vdb->flags & MOD_OPENVDB_HIDE_VOLUME)))
 			{
 				if (!sds->wt || !(sds->viewsettings & MOD_SMOKE_VIEW_SHOWBIG)) {
 					sds->tex = NULL;


### PR DESCRIPTION
After rendering, even if "hide volume" was enabled for a certain VDB,
the volume would show up in the viewport, until the next update. This
fixes that issue, and always hides volumes with "hide volume" in the
viewport.