### PR TITLE
Nan mesh light fix

### DIFF
--- a/intern/cycles/bvh/bvh_build.cpp
+++ b/intern/cycles/bvh/bvh_build.cpp
@@ -129,7 +129,7 @@ void BVHBuild::add_reference_triangles(BoundBox& root, BoundBox& center, Mesh *m
 		if(attr_mP == NULL) {
 			BoundBox bounds = BoundBox::empty;
 			t.bounds_grow(verts, bounds);
-			if(bounds.valid()) {
+			if(bounds.valid() && t.valid(verts)) {
 				references.push_back(BVHReference(bounds,
 				                                  j,
 				                                  i,

--- a/intern/cycles/render/light.cpp
+++ b/intern/cycles/render/light.cpp
@@ -346,6 +346,9 @@ void LightManager::device_update_distribution(Device *device, DeviceScene *dscen
 				offset++;
 
 				Mesh::Triangle t = mesh->get_triangle(i);
+				if(!t.valid(&mesh->verts[0])) {
+					continue;
+				}
 				float3 p1 = mesh->verts[t.v[0]];
 				float3 p2 = mesh->verts[t.v[1]];
 				float3 p3 = mesh->verts[t.v[2]];

--- a/intern/cycles/render/light.cpp
+++ b/intern/cycles/render/light.cpp
@@ -230,6 +230,10 @@ void LightManager::disable_ineffective_light(Device *device, Scene *scene)
 
 bool LightManager::object_usable_as_light(Object *object) {
 	Mesh *mesh = object->mesh;
+	/* Skip objects with NaNs */
+	if (!object->bounds.valid()) {
+		return false;
+	}
 	/* Skip if we are not visible for BSDFs. */
 	if(!(object->visibility & (PATH_RAY_DIFFUSE|PATH_RAY_GLOSSY|PATH_RAY_TRANSMIT))) {
 		return false;

--- a/intern/cycles/render/mesh.cpp
+++ b/intern/cycles/render/mesh.cpp
@@ -127,6 +127,11 @@ float3 Mesh::Triangle::compute_normal(const float3 *verts) const
 	return norm / normlen;
 }
 
+inline float isfinite3_safe(const float3 &f)
+{
+	return isfinite_safe(f.x) && isfinite_safe(f.y) && isfinite_safe(f.z);
+}
+
 bool Mesh::Triangle::valid(const float3 *verts) const
 {
 	return isfinite3_safe(verts[v[0]]) &&

--- a/intern/cycles/render/mesh.cpp
+++ b/intern/cycles/render/mesh.cpp
@@ -127,6 +127,13 @@ float3 Mesh::Triangle::compute_normal(const float3 *verts) const
 	return norm / normlen;
 }
 
+bool Mesh::Triangle::valid(const float3 *verts) const
+{
+	return isfinite3_safe(verts[v[0]]) &&
+	       isfinite3_safe(verts[v[1]]) &&
+	       isfinite3_safe(verts[v[2]]);
+}
+
 /* Curve */
 
 void Mesh::Curve::bounds_grow(const int k, const float3 *curve_keys, const float *curve_radius, BoundBox& bounds) const

--- a/intern/cycles/render/mesh.h
+++ b/intern/cycles/render/mesh.h
@@ -72,6 +72,8 @@ public:
 		                    float3 r_verts[3]) const;
 
 		float3 compute_normal(const float3 *verts) const;
+
+		bool valid(const float3 *verts) const;
 	};
 
 	Triangle get_triangle(size_t i) const


### PR DESCRIPTION
This is a cherry-pick of two commits from the official Blender repository. It prevents emissive meshes that have NaNs in their transform (as the particle system may produce them) from screwing up light importance sampling.