### PR TITLE
Fix volume not visible in render with "hide volume"

### DIFF
--- a/source/blender/blenkernel/intern/pointcache.c
+++ b/source/blender/blenkernel/intern/pointcache.c
@@ -3140,6 +3140,10 @@ int BKE_ptcache_read(PTCacheID *pid, float cfra, bool no_extrapolate_old)
 		sds = smd->domain;
 		vdbmd = sds->vdb;
 
+		if (vdbmd->flags & MOD_OPENVDB_NOW_RENDERING) {
+			return 0;
+		}
+
 		cfra1 = cfra2 = -1;
 
 		if (cfrai < pid->cache->startframe || cfrai > pid->cache->endframe) {

--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -1719,6 +1719,7 @@ enum {
 	MOD_OPENVDB_IS_RENDER       = (1 << 4),
 	MOD_OPENVDB_HAS_DENSITY     = (1 << 5),
 	MOD_OPENVDB_SPLIT_VELOCITY  = (1 << 6),
+	MOD_OPENVDB_NOW_RENDERING   = (1 << 7),
 };
 
 enum {

--- a/source/blender/modifiers/intern/MOD_openvdb.c
+++ b/source/blender/modifiers/intern/MOD_openvdb.c
@@ -173,6 +173,10 @@ static DerivedMesh *applyModifier(ModifierData *md, Object *ob,
 		}
 	}
 	else {
+		if (G.is_rendering) {
+			vdbmd->flags |= MOD_OPENVDB_NOW_RENDERING;
+		}
+
 		if ((vdbmd->flags & MOD_OPENVDB_HIDE_UNSELECTED) &&
 			!(ob->flag & SELECT))
 		{


### PR DESCRIPTION
This fixes an issue that caused volumes to disappear in renders when the
"hide volume" or "hide uunselected" display options are enabled.

The issue was that the modifier is called prior to rendering, with the
"MOD_APPLY_RENDER" flag, as expected. However immediately after, and
while still rendering, the modifier is called again, without the render
flag, causing it to be recomputed as it should be for the viewport
display. This happens because Blender allows you to work while
rendering, and thus the display version of the modifiers has to be
computed.

The issue is of course that while this is not a problem for meshes, as
they are copied and passed along the modifier stack, data which is read
directly (such as volume data), is still subject to side-effects.

This commit prevents the modifier from updating the data while a render
is in progress, thus keeping the render data intact. This unfortunately
causes the minor side-effect of full resolution smoke being displayed in
the viewport after rendering, even when the "simplify" option is used.
Note however that this causes no extra data loading, and thus
performance is unaffected. Also note that the hiding options don't
suffer from this side effect, and so if the volume is hidden, it's
hidden state will still be in effect after the render, as hiding does
not rely on the cache being reloaded.