### PR TITLE
Cycles: Added native support for UINT16 textures to CUDA and CPU devi…

### DIFF
--- a/intern/cycles/device/device_cuda.cpp
+++ b/intern/cycles/device/device_cuda.cpp
@@ -633,6 +633,7 @@ public:
 		CUarray_format_enum format;
 		switch(mem.data_type) {
 			case TYPE_UCHAR: format = CU_AD_FORMAT_UNSIGNED_INT8; break;
+			case TYPE_UINT16: format = CU_AD_FORMAT_UNSIGNED_INT16; break;
 			case TYPE_UINT: format = CU_AD_FORMAT_UNSIGNED_INT32; break;
 			case TYPE_INT: format = CU_AD_FORMAT_SIGNED_INT32; break;
 			case TYPE_FLOAT: format = CU_AD_FORMAT_FLOAT; break;

--- a/intern/cycles/device/device_memory.h
+++ b/intern/cycles/device/device_memory.h
@@ -45,6 +45,7 @@ enum MemoryType {
 
 enum DataType {
 	TYPE_UCHAR,
+	TYPE_UINT16,
 	TYPE_UINT,
 	TYPE_INT,
 	TYPE_FLOAT,
@@ -57,6 +58,7 @@ static inline size_t datatype_size(DataType datatype)
 	switch(datatype) {
 		case TYPE_UCHAR: return sizeof(uchar);
 		case TYPE_FLOAT: return sizeof(float);
+		case TYPE_UINT16: return sizeof(uint16_t);
 		case TYPE_UINT: return sizeof(uint);
 		case TYPE_INT: return sizeof(int);
 		case TYPE_HALF: return sizeof(half);
@@ -154,6 +156,16 @@ template<> struct device_type_traits<float4> {
 
 template<> struct device_type_traits<half> {
 	static const DataType data_type = TYPE_HALF;
+	static const int num_elements = 1;
+};
+
+template<> struct device_type_traits<ushort4> {
+	static const DataType data_type = TYPE_UINT16;
+	static const int num_elements = 4;
+};
+
+template<> struct device_type_traits<uint16_t> {
+	static const DataType data_type = TYPE_UINT16;
 	static const int num_elements = 1;
 };
 

--- a/intern/cycles/kernel/kernel_compat_cpu.h
+++ b/intern/cycles/kernel/kernel_compat_cpu.h
@@ -156,6 +156,18 @@ template<typename T> struct texture_image  {
 		return make_float4(f, f, f, 1.0f);
 	}
 
+	ccl_always_inline float4 read(uint16_t r)
+	{
+		float f = r*(1.0f/65535.0f);
+		return make_float4(f, f, f, 1.0f);
+	}
+
+	ccl_always_inline float4 read(ushort4 r)
+	{
+		float f = 1.0f/65535.0f;
+		return make_float4(r.x*f, r.y*f, r.z*f, r.w*f);
+	}
+
 	ccl_always_inline int wrap_periodic(int x, int width)
 	{
 		x %= width;
@@ -548,12 +560,16 @@ typedef texture<int> texture_int;
 typedef texture<uint4> texture_uint4;
 typedef texture<uchar4> texture_uchar4;
 typedef texture<uchar> texture_uchar;
+typedef texture<uint16_t> texture_ushort;
+typedef texture<ushort4> texture_ushort_4;
 typedef texture_image<float> texture_image_float;
 typedef texture_image<uchar> texture_image_uchar;
 typedef texture_image<half> texture_image_half;
+typedef texture_image<uint16_t> texture_image_ushort;
 typedef texture_image<float4> texture_image_float4;
 typedef texture_image<uchar4> texture_image_uchar4;
 typedef texture_image<half4> texture_image_half4;
+typedef texture_image<ushort4> texture_image_ushort4;
 
 /* Macros to handle different memory storage on different devices */
 

--- a/intern/cycles/kernel/kernel_globals.h
+++ b/intern/cycles/kernel/kernel_globals.h
@@ -49,9 +49,11 @@ typedef struct KernelGlobals {
 	std::vector<texture_image_uchar4> texture_byte4_images;
 	std::vector<texture_image_float4> texture_float4_images;
 	std::vector<texture_image_half4> texture_half4_images;
+	std::vector<texture_image_ushort4> texture_ushort4_images;
 	std::vector<texture_image_float> texture_float_images;
 	std::vector<texture_image_uchar> texture_byte_images;
 	std::vector<texture_image_half> texture_half_images;
+	std::vector<texture_image_ushort> texture_ushort_images;
 
 #  define KERNEL_TEX(type, ttype, name) ttype name;
 #  define KERNEL_IMAGE_TEX(type, ttype, name)

--- a/intern/cycles/kernel/kernels/cpu/kernel.cpp
+++ b/intern/cycles/kernel/kernels/cpu/kernel.cpp
@@ -200,6 +200,42 @@ void kernel_tex_copy(KernelGlobals *kg,
 			tex->extension = extension;
 		}
 	}
+	else if(strstr(name, "__tex_image_ushort4")) {
+		texture_image_ushort4 *tex = NULL;
+		int id = atoi(name + strlen("__tex_image_ushort4_"));
+		int array_index = kernel_tex_index(id);
+
+		if(array_index >= 0) {
+			if (array_index >= kg->texture_ushort4_images.size())
+				kg->texture_ushort4_images.resize(array_index+1);
+			tex = &kg->texture_ushort4_images[array_index];
+		}
+
+		if(tex) {
+			tex->data = (ushort4*)mem;
+			tex->dimensions_set(width, height, depth);
+			tex->interpolation = interpolation;
+			tex->extension = extension;
+		}
+	}
+	else if(strstr(name, "__tex_image_ushort")) {
+		texture_image_ushort *tex = NULL;
+		int id = atoi(name + strlen("__tex_image_ushort_"));
+		int array_index = kernel_tex_index(id);
+
+		if(array_index >= 0) {
+			if (array_index >= kg->texture_ushort_images.size())
+				kg->texture_ushort_images.resize(array_index+1);
+			tex = &kg->texture_ushort_images[array_index];
+		}
+
+		if(tex) {
+			tex->data = (uint16_t*)mem;
+			tex->dimensions_set(width, height, depth);
+			tex->interpolation = interpolation;
+			tex->extension = extension;
+		}
+	}
 	else
 		assert(0);
 }

--- a/intern/cycles/kernel/kernels/cpu/kernel_cpu_image.h
+++ b/intern/cycles/kernel/kernels/cpu/kernel_cpu_image.h
@@ -28,12 +28,16 @@ ccl_device float4 kernel_tex_image_interp_impl(KernelGlobals *kg, int tex, float
 			return kg->texture_byte4_images[kernel_tex_index(tex)].interp(x, y);
 		case IMAGE_DATA_TYPE_HALF4:
 			return kg->texture_half4_images[kernel_tex_index(tex)].interp(x, y);
+		case IMAGE_DATA_TYPE_USHORT4:
+			return kg->texture_ushort4_images[kernel_tex_index(tex)].interp(x, y);
 		case IMAGE_DATA_TYPE_FLOAT:
 			return kg->texture_float_images[kernel_tex_index(tex)].interp(x, y);
 		case IMAGE_DATA_TYPE_BYTE:
 			return kg->texture_byte_images[kernel_tex_index(tex)].interp(x, y);
 		case IMAGE_DATA_TYPE_HALF:
 			return kg->texture_half_images[kernel_tex_index(tex)].interp(x, y);
+		case IMAGE_DATA_TYPE_USHORT:
+			return kg->texture_ushort_images[kernel_tex_index(tex)].interp(x, y);
 		case IMAGE_DATA_TYPE_FLOAT4:
 		default:
 			return kg->texture_float4_images[kernel_tex_index(tex)].interp(x, y);
@@ -47,12 +51,16 @@ ccl_device float4 kernel_tex_image_interp_3d_impl(KernelGlobals *kg, int tex, fl
 			return kg->texture_byte4_images[kernel_tex_index(tex)].interp_3d(x, y, z);
 		case IMAGE_DATA_TYPE_HALF4:
 			return kg->texture_half4_images[kernel_tex_index(tex)].interp_3d(x, y, z);
+		case IMAGE_DATA_TYPE_USHORT4:
+			return kg->texture_ushort4_images[kernel_tex_index(tex)].interp_3d(x, y, z);
 		case IMAGE_DATA_TYPE_FLOAT:
 			return kg->texture_float_images[kernel_tex_index(tex)].interp_3d(x, y, z);
 		case IMAGE_DATA_TYPE_BYTE:
 			return kg->texture_byte_images[kernel_tex_index(tex)].interp_3d(x, y, z);
 		case IMAGE_DATA_TYPE_HALF:
 			return kg->texture_half_images[kernel_tex_index(tex)].interp_3d(x, y, z);
+		case IMAGE_DATA_TYPE_USHORT:
+			return kg->texture_ushort_images[kernel_tex_index(tex)].interp_3d(x, y, z);
 		case IMAGE_DATA_TYPE_FLOAT4:
 		default:
 			return kg->texture_float4_images[kernel_tex_index(tex)].interp_3d(x, y, z);
@@ -66,12 +74,16 @@ ccl_device float4 kernel_tex_image_interp_3d_ex_impl(KernelGlobals *kg, int tex,
 			return kg->texture_byte4_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
 		case IMAGE_DATA_TYPE_HALF4:
 			return kg->texture_half4_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
+		case IMAGE_DATA_TYPE_USHORT4:
+			return kg->texture_ushort4_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
 		case IMAGE_DATA_TYPE_FLOAT:
 			return kg->texture_float_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
 		case IMAGE_DATA_TYPE_BYTE:
 			return kg->texture_byte_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
 		case IMAGE_DATA_TYPE_HALF:
 			return kg->texture_half_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
+		case IMAGE_DATA_TYPE_USHORT:
+			return kg->texture_ushort_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);
 		case IMAGE_DATA_TYPE_FLOAT4:
 		default:
 			return kg->texture_float4_images[kernel_tex_index(tex)].interp_3d_ex(x, y, z, interpolation);

--- a/intern/cycles/kernel/svm/svm_image.h
+++ b/intern/cycles/kernel/svm/svm_image.h
@@ -194,7 +194,8 @@ ccl_device float4 svm_image_texture(KernelGlobals *kg, int id, float x, float y,
 #  else
 	CUtexObject tex = kernel_tex_fetch(__bindless_mapping, id);
 	/* float4, byte4 and half4 */
-	if(kernel_tex_type(id) == IMAGE_DATA_TYPE_FLOAT4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_BYTE4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_HALF4)
+	if(kernel_tex_type(id) == IMAGE_DATA_TYPE_FLOAT4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_BYTE4
+	   || kernel_tex_type(id) == IMAGE_DATA_TYPE_HALF4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_USHORT4)
 		r = kernel_tex_image_interp_float4(tex, x, y);
 	/* float, byte and half */
 	else {

--- a/intern/cycles/kernel/svm/svm_voxel.h
+++ b/intern/cycles/kernel/svm/svm_voxel.h
@@ -46,7 +46,8 @@ ccl_device void svm_node_tex_voxel(KernelGlobals *kg,
 #  if defined(__KERNEL_CUDA__)
 #    if __CUDA_ARCH__ >= 300
 	CUtexObject tex = kernel_tex_fetch(__bindless_mapping, id);
-	if(kernel_tex_type(id) == IMAGE_DATA_TYPE_FLOAT4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_BYTE4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_HALF4)
+	if(kernel_tex_type(id) == IMAGE_DATA_TYPE_FLOAT4 || kernel_tex_type(id) == IMAGE_DATA_TYPE_BYTE4
+	   || kernel_tex_type(id) == IMAGE_DATA_TYPE_HALF4 || IMAGE_DATA_TYPE_USHORT4)
 		r = kernel_tex_image_interp_3d_float4(tex, co.x, co.y, co.z);
 	else {
 		float f = kernel_tex_image_interp_3d_float(tex, co.x, co.y, co.z);

--- a/intern/cycles/render/scene.h
+++ b/intern/cycles/render/scene.h
@@ -120,6 +120,8 @@ public:
 	std::vector<device_vector<uchar>* > tex_byte_image;
 	std::vector<device_vector<half4>* > tex_half4_image;
 	std::vector<device_vector<half>* > tex_half_image;
+	std::vector<device_vector<ushort4>* > tex_ushort4_image;
+	std::vector<device_vector<uint16_t>* > tex_ushort_image;
 	
 	/* opencl images */
 	device_vector<uchar4> tex_image_byte4_packed;

--- a/intern/cycles/util/util_half.h
+++ b/intern/cycles/util/util_half.h
@@ -36,7 +36,16 @@ CCL_NAMESPACE_BEGIN
 
 /* CUDA has its own half data type, no need to define then */
 #ifndef __KERNEL_CUDA__
-typedef unsigned short half;
+/* Implementing this as a class rather than a typedef so that the compiler can tell it apart from unsigned shorts. */
+class half {
+public:
+	half() : v(0) {}
+	half(const unsigned short& i) : v(i) {}
+	operator unsigned short() { return v; }
+	half & operator =(const unsigned short& i) { v = i; return *this; }
+private:
+	unsigned short v;
+};
 #endif
 
 struct half4 { half x, y, z, w; };

--- a/intern/cycles/util/util_types.h
+++ b/intern/cycles/util/util_types.h
@@ -172,6 +172,13 @@ struct uchar4 {
 	__forceinline uchar& operator[](int i) { return *(&x + i); }
 };
 
+struct ushort4 {
+	uint16_t x, y, z, w;
+
+	__forceinline uint16_t operator[](int i) const { return *(&x + i); }
+	__forceinline uint16_t& operator[](int i) { return *(&x + i); }
+};
+
 struct int2 {
 	int x, y;
 
@@ -518,9 +525,11 @@ enum ImageDataType {
 	IMAGE_DATA_TYPE_FLOAT4 = 0,
 	IMAGE_DATA_TYPE_BYTE4 = 1,
 	IMAGE_DATA_TYPE_HALF4 = 2,
-	IMAGE_DATA_TYPE_FLOAT = 3,
-	IMAGE_DATA_TYPE_BYTE = 4,
-	IMAGE_DATA_TYPE_HALF = 5,
+	IMAGE_DATA_TYPE_USHORT4 = 3,
+	IMAGE_DATA_TYPE_FLOAT = 4,
+	IMAGE_DATA_TYPE_BYTE = 5,
+	IMAGE_DATA_TYPE_HALF = 6,
+	IMAGE_DATA_TYPE_USHORT = 7,
 	
 	IMAGE_DATA_NUM_TYPES
 };


### PR DESCRIPTION
…ces.

I noticed we are using a number of 16bit PNG textures that Cycles promotes to 32bit floats, using twice the memory needed. Adding 16bit unsigned integer as native texture format helps us save a lot of memory in those cases.