### PR TITLE
Cycles: fixed BV-5 - state update on volume bounce was overwriting bo…

### DIFF
--- a/intern/cycles/kernel/kernel_volume.h
+++ b/intern/cycles/kernel/kernel_volume.h
@@ -76,8 +76,10 @@ ccl_device_inline void kernel_volume_branch_stack(float distance, VolumeStack *s
 			} while(stack[j].shader != SHADER_NONE);
 			--i;
 		}
-		stack[i].t_enter = 0.0f;
-		stack[i].t_exit = FLT_MAX;
+		else {
+			stack[i].t_enter = 0.0f;
+			stack[i].t_exit = FLT_MAX;
+		}
 	}
 }
 


### PR DESCRIPTION
…unce index and caused early path termination