### PR TITLE
Alembic fix (double import)

### DIFF
--- a/source/blender/alembic/intern/alembic_capi.cc
+++ b/source/blender/alembic/intern/alembic_capi.cc
@@ -905,7 +905,7 @@ bool ABC_import(bContext *C, const char *filepath, float scale, bool is_sequence
 
 		/* setup job */
 		WM_jobs_customdata_set(wm_job, job, import_freejob);
-		WM_jobs_timer(wm_job, 0.1, NC_SCENE | ND_FRAME, NC_SCENE | ND_FRAME);
+		WM_jobs_timer(wm_job, 0.1, 0, NC_SCENE | ND_FRAME);
 		WM_jobs_callbacks(wm_job, import_startjob, NULL, NULL, import_endjob);
 
 		WM_jobs_start(CTX_wm_manager(C), wm_job);

--- a/source/blender/blenkernel/intern/cachefile.c
+++ b/source/blender/blenkernel/intern/cachefile.c
@@ -104,6 +104,7 @@ CacheFile *BKE_cachefile_copy(Main *bmain, CacheFile *cache_file)
 {
 	CacheFile *new_cache_file = BKE_libblock_copy(bmain, &cache_file->id);
 	new_cache_file->handle = NULL;
+	new_cache_file->handle_mutex = BLI_mutex_alloc();
 
 	BLI_listbase_clear(&new_cache_file->object_paths);
 


### PR DESCRIPTION
When initiating an Alembic import job, a scene update is set to run
during the job, possibly causing data conflicts with the Alembic import
thread.

This change makes the scene update run only after the import job is
finished.

This also includes an unrelated fix for a crash at quit.