### PR TITLE
Cycles: adding provisions to prevent volume stack overflow, don't add…

### DIFF
--- a/intern/cycles/kernel/kernel_path_branched.h
+++ b/intern/cycles/kernel/kernel_path_branched.h
@@ -364,7 +364,7 @@ ccl_device void kernel_branched_path_integrate(KernelGlobals *kg, uint rng_hash,
 				if(sd.runtime_flag & SD_RUNTIME_BACKFACING) {
 					for(int i = 0; state.volume_stack[i].shader != SHADER_NONE && i < VOLUME_STACK_SIZE; ++i) {
 						if(state.volume_stack[i].object == sd.object) {
-							state.volume_stack[i].t_exit = volume_ray.t;
+							state.volume_stack[i].t_exit = volume_ray.t > state.volume_stack[i].t_exit ? volume_ray.t : state.volume_stack[i].t_exit;
 							break;
 						}
 					}
@@ -372,15 +372,23 @@ ccl_device void kernel_branched_path_integrate(KernelGlobals *kg, uint rng_hash,
 				}
 				else {
 					int i = 0;
-					while(state.volume_stack[i].shader != SHADER_NONE && i < VOLUME_STACK_SIZE) {
+					bool found = false;
+					while(state.volume_stack[i].shader != SHADER_NONE && i < VOLUME_STACK_SIZE - 1) {
+						if(state.volume_stack[i].object == sd.object) {
+							/* Don't add the object if it is already on the stack. */
+							found = true;
+							break;
+						}
 						++i;
 					}
-					state.volume_stack[i].object = sd.object;
-					state.volume_stack[i].shader = sd.shader;
-					state.volume_stack[i].t_enter = volume_ray.t;
-					state.volume_stack[i].t_exit = FLT_MAX;
-					state.volume_stack[i+1].shader = SHADER_NONE;
-					++volumes_entered;
+					if(!found) {
+						state.volume_stack[i].object = sd.object;
+						state.volume_stack[i].shader = sd.shader;
+						state.volume_stack[i].t_enter = volume_ray.t;
+						state.volume_stack[i].t_exit = FLT_MAX;
+						state.volume_stack[i + 1].shader = SHADER_NONE;
+						++volumes_entered;
+					}
 				}
 			}
 		}

--- a/intern/cycles/kernel/kernel_volume.h
+++ b/intern/cycles/kernel/kernel_volume.h
@@ -67,10 +67,12 @@ ccl_device_inline void kernel_volume_branch_stack(float distance, VolumeStack *s
 	   Set all other volumes to go from zero to infinity.
 	 */
 	for (int i = 0; stack[i].shader != SHADER_NONE; ++i) {
+		assert(i >= 0 && i < VOLUME_STACK_SIZE);
 		if (stack[i].t_exit <distance ||stack[i].t_enter > distance) {
 			int j = i;
 			/* shift back next stack entries */
 			do {
+				assert(j >= 0 && j < VOLUME_STACK_SIZE - 1);
 				stack[j] = stack[j + 1];
 				++j;
 			} while(stack[j].shader != SHADER_NONE);


### PR DESCRIPTION
… the same volume object twice even when there's empty space in between