### PR TITLE
Revert "Cycles: Fixed building GPU kernels with new volume changes"

### DIFF
--- a/intern/cycles/kernel/kernel_volume.h
+++ b/intern/cycles/kernel/kernel_volume.h
@@ -1365,7 +1365,7 @@ ccl_device void kernel_volume_stack_update_for_subsurface(KernelGlobals *kg,
                                  0x00000000/*TODO:shadow_linking*/))
 	{
 		shader_setup_from_ray(kg, stack_sd, &isect, &volume_ray);
-		kernel_volume_stack_enter_exit(kg, stack_sd, state);
+		kernel_volume_stack_enter_exit(kg, stack_sd, stack);
 
 		/* Move ray forward. */
 		volume_ray.P = ray_offset(stack_sd->P, -stack_sd->Ng);


### PR DESCRIPTION
Reverts tangent-animation/blender278#150

I AM REVERTING THIS FOR THE EXPRESS PURPOSE OF TESTING AN ERROR DETECTION CHANGE IN JENKINS AND WILL IMMEDIATELY REVERT BACK AFTER.