### PR TITLE
Fix stack underflow

### DIFF
--- a/intern/cycles/kernel/kernel_path_branched.h
+++ b/intern/cycles/kernel/kernel_path_branched.h
@@ -606,7 +606,9 @@ ccl_device void kernel_branched_path_integrate(KernelGlobals *kg, uint rng_hash,
 					while(state.volume_stack[j].shader != SHADER_NONE && j < volume_stack_size(&state));
 					--i;
 				}
-				state.volume_stack[i].t_enter = 0.0f;
+				if(i > 0) {
+					state.volume_stack[i].t_enter = 0.0f;
+				}
 			}
 			volume_ray.P = save_p;
 		}


### PR DESCRIPTION
Another possible source of memory corruption in deferred ray marching. Added another check to make sure we don't overwrite memory outside of the volume stack.