### PR TITLE
Added a check for scene copying to make sure that scene->world exists.

### DIFF
--- a/source/blender/editors/object/object_relations.c
+++ b/source/blender/editors/object/object_relations.c
@@ -2136,7 +2136,9 @@ void ED_object_single_users(Main *bmain, Scene *scene, const bool full, const bo
 			IDP_RelinkProperty(scene->gpd->id.properties);
 		}
 
-		IDP_RelinkProperty(scene->world->id.properties);
+		if (scene->world) {
+			IDP_RelinkProperty(scene->world->id.properties);
+		}
 
 		if (scene->clip) {
 			IDP_RelinkProperty(scene->clip->id.properties);


### PR DESCRIPTION
There was a problem with a shot when doing a full scene copy causing blender to crash. It turns out that the scene had no world properties so when it tried to relink the world properties it was hitting a NULL causing blender to crash. I made a simple if check to prevent a relink.