### PR TITLE
Cycles: Hardcoding volume mesh isovalue to 0.0 - for some reason, thi…

### DIFF
--- a/intern/cycles/blender/blender_mesh.cpp
+++ b/intern/cycles/blender/blender_mesh.cpp
@@ -287,7 +287,7 @@ static void create_mesh_volume_attribute(BL::Object& b_ob,
 	if(!b_domain)
 		return;
 
-	mesh->volume_isovalue = b_domain.clipping();
+	mesh->volume_isovalue = 0.0f; /*b_domain.clipping() */;
 
 	Attribute *attr = mesh->attributes.add(std);
 	VoxelAttribute *volume_data = attr->data_voxel();


### PR DESCRIPTION
…s worked differently between preview and final render.

This is a followup to my previous commit, fixing it in another place.